### PR TITLE
Allow passing arguments to the rustdoc command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ travis-ci = { repository = "assert-rs/docmatic" }
 appveyor  = { repository = "epage/docmatic" }
 
 [dependencies]
-glob = "0.2"
 which = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "docmatic"
 version = "0.1.1"
-authors = ["Ed Page <eopage@gmail.com>"]
+authors = ["Ed Page <eopage@gmail.com>", "Martin Larralde <martin.larralde@ens-paris-saclay.fr>"]
 description = "Test Rust examples in your documentation."
 repository = "https://github.com/assert-rs/docmatic"
 documentation = "https://docs.rs/docmatic"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@
 //! }
 //! ```
 
-extern crate glob;
 extern crate which;
 
 use std::path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,32 +30,99 @@ extern crate glob;
 extern crate which;
 
 use std::path;
+use std::ffi::OsStr;
 
+/// The `Assert` type is a specialized process builder made to manage `rustdoc`
+/// test sessions.
+///
+/// # Example
+///
+/// The following code will test the crate README with the `docmatic`
+/// configuration set and a default library path:
+///
+/// ```rust
+/// extern crate docmatic;
+///
+/// use std::default::Default;
+///
+/// fn test_readme() {
+///     docmatic::Assert::default()
+///         .cfg("docmatic")
+///         .test_file("README.md")
+/// }
+/// ```
+pub struct Assert(std::process::Command);
+
+impl Assert {
+    /// Construct a new `Assert` with no flags set.
+    ///
+    /// Will likely fail if you don't provide at least one library path
+    /// containing the tested crate. Instead, you should probably use
+    /// [`Assert::default`]
+    ///
+    /// [`Assert::default`]: #tymethod.default
+    pub fn new() -> Self {
+        let executable = which::which("rustdoc").expect("rustdoc not found");
+        Assert(std::process::Command::new(executable))
+    }
+
+    /// Add a path to the library paths passed to `rustdoc`.
+    pub fn library_path<S>(&mut self, path: S) -> &mut Self
+    where
+        S: AsRef<OsStr>,
+    {
+        self.0.arg("--library-path").arg(path);
+        self
+    }
+
+    /// Add a *cfg* to the configuration passed to `rustdoc`.
+    pub fn cfg<S>(&mut self, cfg: S) -> &mut Self
+    where
+        S: AsRef<OsStr>,
+    {
+        self.0.arg("--cfg").arg(cfg);
+        self
+    }
+
+    /// Test the given file, and panics on failure.
+    pub fn test_file<P>(&mut self, path: P)
+    where
+        P: AsRef<path::Path>,
+    {
+        let process = self.0.arg("--test").arg(path.as_ref()).spawn();
+
+        let result = process
+            .expect("rustdoc is runnable")
+            .wait()
+            .expect("rustdoc can run");
+
+        assert!(
+            result.success(),
+            format!("Failed to run rustdoc tests on '{:?}'", path.as_ref())
+        );
+    }
+}
+
+impl Default for Assert {
+    /// Create an `Assert` instance with the following default parameters:
+    ///
+    /// * `--library-path` set to the current *deps* directory (`target/debug/deps` or
+    ///   `target/release/deps` depending on the test compilation mode).
+    ///
+    fn default() -> Self {
+        let mut assert = Self::new();
+        let current_exe = std::env::current_exe()
+            .and_then(|p| p.canonicalize())
+            .expect("could not get path to test executable");
+        assert.library_path(current_exe.parent().expect("parent exists"));
+        assert
+    }
+}
+
+/// Test a single file with default parameters.
 pub fn assert_file<P>(documentation: P)
 where
     P: AsRef<path::Path>,
 {
-    assert_file_impl(documentation.as_ref())
-}
-
-fn assert_file_impl(documentation: &path::Path) {
-    let rustdoc = which::which("rustdoc").expect("run with rust toolchain available");
-
-    let current_exe = std::path::Path::new(&std::env::current_exe().unwrap())
-        .canonicalize()
-        .unwrap();
-    let deps = current_exe.parent().unwrap();
-
-    let mut cmd = std::process::Command::new(rustdoc);
-    cmd.arg("--verbose")
-        .args(&["--library-path", deps.to_str().unwrap()])
-        .arg("--test")
-        .arg(documentation);
-
-    let result = cmd.spawn()
-        .expect("rustdoc is runnable")
-        .wait()
-        .expect("rustdoc can run");
-
-    assert!(result.success(), "Failed to run rustdoc tests on README.md");
+    Assert::default().test_file(documentation);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,7 @@ extern crate which;
 use std::path;
 use std::ffi::OsStr;
 
-/// The `Assert` type is a specialized process builder made to manage `rustdoc`
-/// test sessions.
+/// A specialized process builder managing a `rustdoc` test session.
 ///
 /// # Example
 ///

--- a/tests/test_readme.rs
+++ b/tests/test_readme.rs
@@ -1,0 +1,6 @@
+extern crate docmatic;
+
+#[test]
+fn test_readme() {
+    docmatic::assert_file("README.md");
+}


### PR DESCRIPTION
Hi there,

I was working on porting the `pyo3` documentation to use docmatic (PyO3/pyo3#142), but unfortunately it does not work out of the box since it links to the `libpython`, which may be in a non-standard location. 

I added the possibility to pass additional arguments to the `rustdoc` command, so that we can in our case pass additional `--library-path` flags.

The only drawback is that all arguments must have the same type, but it's safe to use `String` everywhere in that case.

(I also removed the `glob` dependency since it's not used anywhere...)