### PR TITLE
Fix the example in src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! ```rust
 //! extern crate docmatic;
 //!
+//! #[test]
 //! fn test_readme() {
 //!     docmatic::assert_file("README.md");
 //! }


### PR DESCRIPTION
The function in the test file has to be annotated with `#[test]`.

<!--
Quick reminders:
- Were tests written?
- Is commit history clean?
- Were copyright statements updated?
-->
